### PR TITLE
Bugfix: incorrect harmonic check

### DIFF
--- a/candidate_filter/known_filter.py
+++ b/candidate_filter/known_filter.py
@@ -32,7 +32,7 @@ def get_known_rfi(cand_freqs,args):
     # Whole number indices
     #numbers = np.arange(1,opts.h_no,1)
 
-    h = np.arange(1,args.harmonics)
+    h = np.arange(1,args.harmonics+1)
     ratios = np.outer(h,1.0/h)
     all_ratios = np.unique(np.sort(ratios.ravel()))
 
@@ -43,7 +43,7 @@ def get_known_rfi(cand_freqs,args):
 
     for number in all_ratios:
         for rfi in known_rfi_freqs:
-            w_harmonics.append([a for a in cand_freqs if abs(a - round(number*rfi))/(a)<args.p_tol])
+            w_harmonics.append([a for a in cand_freqs if abs(a - number*rfi)/(a)<args.p_tol])
 
     all_harmonics=sorted(list(set(list(itertools.chain(*w_harmonics)))))
     rfi_indices = np.array([np.where(cand_freqs==h)[0][0] for h in all_harmonics])


### PR DESCRIPTION
The RFI harmonic check has two bugs:
1. the range for the checked harmonics should go 1 --> n+1 (otherwise a user asking for no harmonic checks gets no checks at all)
2. there was a round() call on line 44 that completely breaks the frequency check for the RFI harmonics.